### PR TITLE
fix: resolve dependabot uuid vulnerability (#44)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/viplatform/mui-drawer/issues"
   },
   "homepage": "https://github.com/viplatform/mui-drawer#readme",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "files": [
     "dist"
   ],
@@ -61,7 +61,8 @@
     "flatted": ">=3.4.2",
     "handlebars": ">=4.7.9",
     "picomatch": ">=4.0.4",
-    "vite": "^7.3.2"
+    "vite": "^7.3.2",
+    "uuid": "^14.0.0"
   },
   "peerDependencies": {
     "@emotion/react": "^11.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6544,10 +6544,10 @@ util@^0.12.5:
     is-typed-array "^1.1.3"
     which-typed-array "^1.1.2"
 
-uuid@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+uuid@^14.0.0, uuid@^9.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary
- Adds yarn resolution `uuid: ^14.0.0` to force the transitively-pulled storybook dependency off the vulnerable `uuid@9.0.1`.
- Resolves [dependabot alert #44](https://github.com/viplatform/mui-drawer/security/dependabot/44) (medium): missing buffer bounds check in uuid v3/v5/v6.
- Bumps package version to 1.0.27.

## Test plan
- [x] `yarn install` regenerates lockfile with `uuid@14.0.0`
- [x] `yarn build` succeeds (lint + tsc + vite build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)